### PR TITLE
Fail setup.sh if any command fails

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -e
+
 cd /app
 
 echo "Getting deps"


### PR DESCRIPTION
Currently setup.sh steps can fail without failing the build, which leads to a broken docker image. This seems to be the case for the arm64 build of tag [`1.12.0`](https://hub.docker.com/layers/madnificent/elixir-server/1.12.0/images/sha256-db3c20688cbc688652f781ab93f31215e0677b572de9d3012e7121e71d2fd066) as well as the [`latest`](https://hub.docker.com/layers/madnificent/elixir-server/latest/images/sha256-272c747381dd90a0c69329ba6f9a13dbed11461d94a23627677c51c39bf99e75). This is in turn causing the arm64 builds of mu-identifier and mu-dispatcher to fail to run.